### PR TITLE
[fix] PHP notices on fresh install

### DIFF
--- a/include/admin_menu.php
+++ b/include/admin_menu.php
@@ -17,7 +17,7 @@ function years_callback() {
 	
 	$settings = (array) get_option( 'epflcse-settings' );
 	$field = "years";
-	$value = esc_attr( $settings[$field] );
+	$value = esc_attr( $settings[$field] ?? null );
 	
 	echo "<input type='text' name='epflcse-settings[$field]' value='$value' />";
 }
@@ -25,7 +25,7 @@ function section_callback() {
 	
 	$settings = (array) get_option( 'epflcse-settings' );
 	$field = "section";
-	$value = esc_attr( $settings[$field] );
+	$value = esc_attr( $settings[$field] ?? null );
 	
 	echo "<input type='text' name='epflcse-settings[$field]' value='$value' />";
 }
@@ -33,18 +33,18 @@ function use_polyperspectives_callback() {
 	
 	$settings = (array) get_option( 'epflcse-settings' );
 	$field = "use_polyperspectives";
-	$value = esc_attr( $settings[$field] );
+	$value = esc_attr( $settings[$field] ?? null );
 ?>
-	<input type='checkbox' name='epflcse-settings[use_polyperspectives]' <?php checked( $settings['use_polyperspectives'], 1 ); ?> value='1'/>
+	<input type='checkbox' name='epflcse-settings[use_polyperspectives]' <?php checked( $settings['use_polyperspectives'] ?? null, 1 ); ?> value='1'/>
 <?php
 }
 function use_keywords_callback() {
 	
 	$settings = (array) get_option( 'epflcse-settings' );
 	$field = "use_keywords";
-	$value = esc_attr( $settings[$field] );
+	$value = esc_attr( $settings[$field] ?? null );
 ?>
-	<input type='checkbox' name='epflcse-settings[use_keywords]' <?php checked( $settings['use_keywords'], 1 ); ?> value='1'/>
+	<input type='checkbox' name='epflcse-settings[use_keywords]' <?php checked( $settings['use_keywords'] ?? null, 1 ); ?> value='1'/>
 <?php
 }
 


### PR DESCRIPTION
Freshly installed on a environnement with debugging on, some notices are 
displayed on unexisting value. Using the "null coalescing operator" on 
these values fix that.